### PR TITLE
Add ```set_temperature``` service

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,22 @@ Use this service to reset the integral part of the PID controller to 0. Useful
 when tuning the PID gains to quickly test the behavior without waiting the integral to stabilize by 
 itself.
 
+**Set PID mode:** `smart_thermostat.set_pid_mode`\
+Use this service to set the PID mode to either 'auto' or 'off'.\
+When in auto, the PID will modulate the heating based on temperature value and variation. When in
+off, the PID output will be 0% if temperature is above the set point, and 100% if temperature is
+below the set point.\
+Mode is saved to Home Assistant database and restored after a restart.\
+Required parameter : mode as a string in ['auto', 'off'].\
+Example:
+```
+service: smart_thermostat.set_temperature
+data:
+  temperature: 21
+target:
+  entity_id: climate.smart_thermostat_example
+```
+
 
 ## Parameters:
 * **name** (Optional): Name of the thermostat.
@@ -309,4 +325,3 @@ This code is a fork from Smart Thermostat PID project:
 [https://github.com/aendle/custom_components](https://github.com/aendle/custom_components) \
 The python PID module with Autotune is based on pid-autotune:
 [https://github.com/hirschmann/pid-autotune](https://github.com/hirschmann/pid-autotune)
-

--- a/custom_components/smart_thermostat/climate.py
+++ b/custom_components/smart_thermostat/climate.py
@@ -259,6 +259,13 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
         "async_set_pid_mode",
     )
     platform.async_register_entity_service(  # type: ignore
+        "set_temperature",
+        {
+            vol.Required(ATTR_TEMPERATURE): vol.Coerce(float),
+        },
+        "async_set_temperature",
+    )
+    platform.async_register_entity_service(  # type: ignore
         "set_preset_temp",
         {
             vol.Optional("away_temp"): vol.All(vol.Coerce(float), vol.Range(

--- a/custom_components/smart_thermostat/services.yaml
+++ b/custom_components/smart_thermostat/services.yaml
@@ -271,3 +271,30 @@ set_preset_temp:
           max: 95
           step: 0.1
           mode: slider
+set_temperature:
+  # Service name as shown in UI
+  name: Set temperature
+  # Description of the service
+  description: Set target temperature
+  target:
+    entity:
+      integration: smart_thermostat
+      domain: climate
+  # If the service accepts entity IDs, target allows the user to specify entities by entity, device, or area. If `target` is specified, `entity_id` should not be defined in the `fields` map. By default it shows only targets matching entities from the same domain as the service, but if further customization is required, target supports the entity, device, and area selectors (https://www.home-assistant.io/docs/blueprint/selectors/). Entity selector parameters will automatically be applied to device and area, and device selector parameters will automatically be applied to area.
+  fields:
+    temperature:
+      name: Temperature
+      # Description of the field
+      description: Target temperature
+      # Whether or not field is required (default = false)
+      required: true
+      # Advanced fields are only shown when the advanced mode is enabled for the user (default = false)
+      advanced: false
+      # Example value that can be passed for this field
+      example: 25
+      selector:
+        number:
+          min: 0
+          max: 1000000
+          step: 0.1
+          mode: box


### PR DESCRIPTION
This service is to allow setting the target temperature via service much like the
default climate domain service.  Since it seems we have a single target it cannot
follow the default interface parameters, instead taking a single parameter to the
service 'Temperature'

Not really a Python or HASS developer but figured I'd share back the changes I made for my own purposes.

Open to constructive criticism of course :)