### PR TITLE
add config option force_synced

### DIFF
--- a/custom_components/smart_thermostat/climate.py
+++ b/custom_components/smart_thermostat/climate.py
@@ -71,6 +71,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
         vol.Required(const.CONF_SENSOR): cv.entity_id,
         vol.Optional(const.CONF_OUTDOOR_SENSOR): cv.entity_id,
         vol.Optional(const.CONF_AC_MODE): cv.boolean,
+        vol.Optional(const.CONF_FORCE_SYNCED): cv.boolean,
         vol.Optional(const.CONF_MAX_TEMP): vol.Coerce(float),
         vol.Optional(const.CONF_MIN_TEMP): vol.Coerce(float),
         vol.Optional(CONF_NAME, default=const.DEFAULT_NAME): cv.string,
@@ -151,6 +152,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
         'hot_tolerance': config.get(const.CONF_HOT_TOLERANCE),
         'cold_tolerance': config.get(const.CONF_COLD_TOLERANCE),
         'ac_mode': config.get(const.CONF_AC_MODE),
+        'force_synced': config.get(const.CONF_FORCE_SYNCED),
         'min_cycle_duration': config.get(const.CONF_MIN_CYCLE_DURATION),
         'min_off_cycle_duration': config.get(const.CONF_MIN_OFF_CYCLE_DURATION),
         'min_cycle_duration_pid_off': config.get(const.CONF_MIN_CYCLE_DURATION_PID_OFF),
@@ -245,6 +247,7 @@ class SmartThermostat(ClimateEntity, RestoreEntity, ABC):
         if self._unique_id == 'none':
             self._unique_id = slugify(f"{DOMAIN}_{self._name}_{self._heater_entity_id}")
         self._ac_mode = kwargs.get('ac_mode')
+        self._force_synced = kwargs.get('force_synced')
         self._keep_alive = kwargs.get('keep_alive')
         self._sampling_period = kwargs.get('sampling_period').seconds
         self._sensor_stall = kwargs.get('sensor_stall').seconds
@@ -867,7 +870,7 @@ class SmartThermostat(ClimateEntity, RestoreEntity, ABC):
                              "Thermostat.", self.entity_id, self._current_temp, self._target_temp)
 
             if not self._active or self._hvac_mode == HVACMode.OFF:
-                if self._hvac_mode == HVACMode.OFF and self._is_device_active:
+                if self._hvac_mode == HVACMode.OFF and self._is_device_active and self._force_synced:
                     _LOGGER.debug("%s: %s is active while HVAC mode is %s. Turning it OFF.",
                                   self.entity_id, self._heater_entity_id, self._hvac_mode)
                     if self._pwm:

--- a/custom_components/smart_thermostat/const.py
+++ b/custom_components/smart_thermostat/const.py
@@ -28,6 +28,7 @@ CONF_TARGET_TEMP = "target_temp"
 CONF_HOT_TOLERANCE = "hot_tolerance"
 CONF_COLD_TOLERANCE = "cold_tolerance"
 CONF_AC_MODE = "ac_mode"
+CONF_FORCE_SYNCED = "force_synced"
 CONF_MIN_CYCLE_DURATION = "min_cycle_duration"
 CONF_MIN_OFF_CYCLE_DURATION = "min_off_cycle_duration"
 CONF_MIN_CYCLE_DURATION_PID_OFF = 'min_cycle_duration_pid_off'


### PR DESCRIPTION
according to https://github.com/ScratMan/HASmartThermostat/issues/136 I did a small test to include a config option to say weather the heater entity should be forced to OFF if the climate entity is OFF or if it should be controllable by HA.
I don't know how to include a standard value, so I was not able to set standard to how it now works and only use my changes if specified. Maybe someone can add this...