### PR TITLE
Fix of visual feedback of IDLE/HEATING state when using valve and pwm is zero

### DIFF
--- a/custom_components/smart_thermostat/climate.py
+++ b/custom_components/smart_thermostat/climate.py
@@ -971,8 +971,6 @@ class SmartThermostat(ClimateEntity, RestoreEntity, ABC):
             return self.hass.states.is_state(self.heater_or_cooler_entity, STATE_ON)
         else:
             """If the valve device is currently active."""
-            if self._heater_polarity_invert:
-                return float(self.hass.states.get(self.heater_or_cooler_entity).state) == 0
             return float(self.hass.states.get(self.heater_or_cooler_entity).state) > 0
       
     @property

--- a/custom_components/smart_thermostat/climate.py
+++ b/custom_components/smart_thermostat/climate.py
@@ -964,11 +964,17 @@ class SmartThermostat(ClimateEntity, RestoreEntity, ABC):
 
     @property
     def _is_device_active(self):
-        """If the toggleable device is currently active."""
-        if self._heater_polarity_invert:
-            return self.hass.states.is_state(self.heater_or_cooler_entity, STATE_OFF)
-        return self.hass.states.is_state(self.heater_or_cooler_entity, STATE_ON)
-
+        if self._pwm:
+            """If the toggleable device is currently active."""
+            if self._heater_polarity_invert:
+                return self.hass.states.is_state(self.heater_or_cooler_entity, STATE_OFF)
+            return self.hass.states.is_state(self.heater_or_cooler_entity, STATE_ON)
+        else:
+            """If the valve device is currently active."""
+            if self._heater_polarity_invert:
+                return float(self.hass.states.get(self.heater_or_cooler_entity).state) == 0
+            return float(self.hass.states.get(self.heater_or_cooler_entity).state) > 0
+      
     @property
     def supported_features(self):
         """Return the list of supported features."""


### PR DESCRIPTION
Issue: 
In the current implementation of the `hvac_action` property the `_is_device_active `property is used to decide whether the device is active or not. 
But `_is_device_active` property only checks if the (toggle) heating entity state is `OFF` or `ON`.
When setting `pwm: 0` the heating entity is considered a valve like entity which is able to accept values between 0-100 and therefore it does not have `ON/OFF` states. As a consequence in `pwm: 0` mode the `_is_device_active` property returns always false -> the `hvac_action` is always `IDLE` even if the `control_output` is above 0 or even when it's 100.
Fix:
There is a branch added to `_is_device_active` to check whether we're in `pwm` mode or not (aka. toggle or valve device is used) and if non `pwm` mode then the return value of the property is based on the float value of the valve device state (ON if state > 0, OFF if state == 0).
