### PR TITLE
Do not throw an error if heater/cooler entity is not yet available on startup

### DIFF
--- a/custom_components/smart_thermostat/climate.py
+++ b/custom_components/smart_thermostat/climate.py
@@ -971,7 +971,10 @@ class SmartThermostat(ClimateEntity, RestoreEntity, ABC):
             return self.hass.states.is_state(self.heater_or_cooler_entity, STATE_ON)
         else:
             """If the valve device is currently active."""
-            return float(self.hass.states.get(self.heater_or_cooler_entity).state) > 0
+            try: # do not throw an error if the state is not yet available on startup
+                return float(self.hass.states.get(self.heater_or_cooler_entity).state) > 0
+            except:
+                return False
       
     @property
     def supported_features(self):


### PR DESCRIPTION
There can be troubles when optimistically convert state value to float:

`float(self.hass.states.get(self.heater_or_cooler_entity).state)`

Fixes #170 