### PR TITLE
 Duty cycle messed up - False reset of time_changed variable - Fix

### DIFF
--- a/custom_components/smart_thermostat/climate.py
+++ b/custom_components/smart_thermostat/climate.py
@@ -1135,15 +1135,13 @@ class SmartThermostat(ClimateEntity, RestoreEntity, ABC):
                     _LOGGER.info("%s: Output is %s. Request turning ON %s", self.entity_id,
                                  self._difference, self.heater_or_cooler_entity)
                     await self._async_heater_turn_on()
-                    self._time_changed = time.time()
             elif abs(self._control_output) > 0:
-                await self.pwm_switch(time_on, time_off, time.time() - self._time_changed)
+                await self.pwm_switch(time_on, time_off, time.time() - self._last_heat_cycle_time)
             else:
                 if self._is_device_active:
                     _LOGGER.info("%s: Output is 0. Request turning OFF %s", self.entity_id,
                                  self.heater_or_cooler_entity)
                     await self._async_heater_turn_off()
-                    self._time_changed = time.time()
         else:
             _LOGGER.info("%s: Change state of %s to %s", self.entity_id,
                          self.heater_or_cooler_entity,
@@ -1163,7 +1161,6 @@ class SmartThermostat(ClimateEntity, RestoreEntity, ABC):
                 _LOGGER.info("%s: ON time passed. Request turning OFF %s", self.entity_id,
                              self.heater_or_cooler_entity)
                 await self._async_heater_turn_off()
-                self._time_changed = time.time()
             else:
                 _LOGGER.info("%s: Time until %s turns OFF: %s sec", self.entity_id,
                              self.heater_or_cooler_entity, int(time_on - time_passed))
@@ -1172,7 +1169,6 @@ class SmartThermostat(ClimateEntity, RestoreEntity, ABC):
                 _LOGGER.info("%s: OFF time passed. Request turning ON %s", self.entity_id,
                              self.heater_or_cooler_entity)
                 await self._async_heater_turn_on()
-                self._time_changed = time.time()
             else:
                 _LOGGER.info("%s: Time until %s turns ON: %s sec", self.entity_id,
                              self.heater_or_cooler_entity, int(time_off - time_passed))

--- a/custom_components/smart_thermostat/climate.py
+++ b/custom_components/smart_thermostat/climate.py
@@ -261,7 +261,7 @@ class SmartThermostat(ClimateEntity, RestoreEntity, ABC):
         self._temp_precision = kwargs.get('precision')
         self._target_temperature_step = kwargs.get('target_temp_step')
         self._debug = kwargs.get(const.CONF_DEBUG)
-        self._last_heat_cycle_time = time.time()
+        self._last_heat_cycle_time = 0
         self._min_on_cycle_duration_pid_on = kwargs.get('min_cycle_duration')
         self._min_off_cycle_duration_pid_on = kwargs.get('min_off_cycle_duration')
         self._min_on_cycle_duration_pid_off = kwargs.get('min_cycle_duration_pid_off')


### PR DESCRIPTION
I ran into a problem where my actuator was switching on/off more often than my PWM interval was long.
This can be reproduced if, for example, you set the pwm to 1800 seconds and the min_cycle_duration to 150 seconds. Since the time_changed variable is incorrectly set to time.time() before the actual switching, the activation duration is extended beyond the calculated on duration, and the duty cycle gets mixed up a lot.
The solution to the problem is to remove the variable time_changed completely, which is reset before the service is called, and adapt the check to the variable last_heat_cycle_time set in _async_heater_turn_off/on.

Additionally, I don't understand why last_heat_cycle_time is initialized with the current time. This means that the first control always fails after a reload. Therefore I initialized it with 0. Of course, in practice this will result in the min_cycle_duration being undershot during a reload/restart, but it makes more sense to me in practice.
Of course, it would be perfect to maintain the value throughout a reload, but I personally don't see it as necessary.

Cheers and thank you for this project. This is my first time participating in a github project, so let me know if I do anything wrong, thanks.