### PR TITLE
Add compatibility with light as heater/cooler entity.

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,13 +225,15 @@ gains to quickly test the behavior without waiting the integral to stabilize by 
 * **name** (Optional): Name of the thermostat.
 * **unique_id** (Optional): unique entity_id for the smart thermostat.
 * **heater** (Required): entity_id for heater control, should be a single or list of toggle 
-device, or valve accepting direct input between 0% and 100%. If a valve is used, pwm parameter 
-should be set to 0. Becomes air conditioning switch when ac_mode is set to true.
+device (switch or input_boolean), light or valve (light, number, input_number). If a valve 
+or a light entity is used, pwm parameter should be set to 0. Becomes air conditioning switch 
+when ac_mode is set to true.
 If you have e.g. multiple radiators in one room, you can enter all of them in a list, and the 
 thermostat will apply the output value to each of them.
 * **cooler** (Optional): entity_id for cooling control, should be a single or list of toggle 
-device, or a valve accepting direct input between 0% and 100%. If a valve is used, pwm parameter 
-should be set to 0. Becomes air conditioning switch when ac_mode is set to true.
+device (switch or input_boolean), light or valve (light, number, input_number). If a valve 
+or a light is used, pwm parameter should be set to 0. Becomes air conditioning switch when 
+ac_mode is set to true.
 * **invert_heater** (Optional): if set to true, inverts the polarity of heater switch (switch is on 
 while idle and off while active). Must be a boolean (defaults to false).
 * **target_sensor** (Required): entity_id for a temperature sensor, target_sensor.state must be 
@@ -251,7 +253,7 @@ values instead.
 * **pwm** (Optional): Set period of the pulse width modulation. If too long, the response time of 
 the thermostat will be too slow, leading to lower accuracy of temperature control. Can be float in 
 seconds or time hh:mm:ss (default 15mn). Set to 0 when using heater entity with direct input of 
-0/100% values like valves.
+0/100% values like valves or lights.
 * **min_cycle_duration** (Optional): Set a minimum amount of time that the switch specified in the 
 heater option must be in its current state prior to being switched either off or on (useful to 
 protect boilers). Can be float in seconds or time hh:mm:ss (default 0s).

--- a/custom_components/smart_thermostat/climate.py
+++ b/custom_components/smart_thermostat/climate.py
@@ -33,6 +33,8 @@ from homeassistant.components.number.const import (
     DOMAIN as NUMBER_DOMAIN
 )
 from homeassistant.components.input_number import DOMAIN as INPUT_NUMBER_DOMAIN
+from homeassistant.components.light import (DOMAIN as LIGHT_DOMAIN, SERVICE_TURN_ON as SERVICE_TURN_LIGHT_ON,
+                                            ATTR_BRIGHTNESS_PCT)
 from homeassistant.core import DOMAIN as HA_DOMAIN, CoreState, Event, EventStateChangedData, callback
 from homeassistant.util import slugify
 import homeassistant.helpers.config_validation as cv
@@ -990,11 +992,18 @@ class SmartThermostat(ClimateEntity, RestoreEntity, ABC):
         _LOGGER.info("%s: Change state of %s to %s", self.entity_id,
                      ", ".join([entity for entity in self.heater_or_cooler_entity]), value)
         for heater_or_cooler_entity in self.heater_or_cooler_entity:
-            data = {ATTR_ENTITY_ID: heater_or_cooler_entity, ATTR_VALUE: value}
-            await self.hass.services.async_call(
-                self._get_number_entity_domain(heater_or_cooler_entity),
-                SERVICE_SET_VALUE,
-                data)
+            if heater_or_cooler_entity[0:6] == 'light.':
+                data = {ATTR_ENTITY_ID: heater_or_cooler_entity, ATTR_BRIGHTNESS_PCT: value}
+                await self.hass.services.async_call(
+                    LIGHT_DOMAIN,
+                    SERVICE_TURN_LIGHT_ON,
+                    data)
+            else:
+                data = {ATTR_ENTITY_ID: heater_or_cooler_entity, ATTR_VALUE: value}
+                await self.hass.services.async_call(
+                    self._get_number_entity_domain(heater_or_cooler_entity),
+                    SERVICE_SET_VALUE,
+                    data)
 
     async def async_set_preset_mode(self, preset_mode: str):
         """Set new preset mode.

--- a/custom_components/smart_thermostat/manifest.json
+++ b/custom_components/smart_thermostat/manifest.json
@@ -7,5 +7,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/ScratMan/HASmartThermostat/issues",
   "requirements": [],
-  "version": "2024.6.0"
+  "version": "2024.6.1"
 }


### PR DESCRIPTION
Add the capability to directly drive a device seen as a `light` in Home Assistant, the thermostat will set its `brightness_pct` attribute. Should definitely close #25 