### PR TITLE
Support Speed Fan as valve-like output

### DIFF
--- a/custom_components/smart_thermostat/climate.py
+++ b/custom_components/smart_thermostat/climate.py
@@ -36,6 +36,7 @@ from homeassistant.components.input_number import DOMAIN as INPUT_NUMBER_DOMAIN
 from homeassistant.components.light import (DOMAIN as LIGHT_DOMAIN, SERVICE_TURN_ON as SERVICE_TURN_LIGHT_ON,
                                             ATTR_BRIGHTNESS_PCT)
 from homeassistant.components.valve import (DOMAIN as VALVE_DOMAIN, SERVICE_SET_VALVE_POSITION, ATTR_POSITION)
+from homeassistant.components.fan import (DOMAIN as FAN_DOMAIN, SERVICE_TURN_ON as SERVICE_TURN_FAN_ON, ATTR_PERCENTAGE)
 from homeassistant.core import DOMAIN as HA_DOMAIN, CoreState, Event, EventStateChangedData, callback
 from homeassistant.util import slugify
 import homeassistant.helpers.config_validation as cv
@@ -1023,6 +1024,12 @@ class SmartThermostat(ClimateEntity, RestoreEntity, ABC):
                 await self.hass.services.async_call(
                     VALVE_DOMAIN,
                     SERVICE_SET_VALVE_POSITION,
+                    data)
+            elif heater_or_cooler_entity[0:4] == 'fan.':
+                data = {ATTR_ENTITY_ID: heater_or_cooler_entity, ATTR_PERCENTAGE: value}
+                await self.hass.services.async_call(
+                    FAN_DOMAIN,
+                    SERVICE_TURN_FAN_ON,
                     data)
             else:
                 data = {ATTR_ENTITY_ID: heater_or_cooler_entity, ATTR_VALUE: value}


### PR DESCRIPTION
I'd like to use this to control a speed fan. Tested in my own HA (sensor & target are humidity values here):

```
2025-02-12 23:53:07.563 DEBUG (MainThread) [custom_components.smart_thermostat.climate] climate.tent_pid_humidity_exhaust: Received new temperature: 58.55
2025-02-12 23:53:07.563 INFO (MainThread) [custom_components.smart_thermostat.climate] climate.tent_pid_humidity_exhaust: Obtained temperature 58.55 with set point 50.0. Activating SmartThermostat.
2025-02-12 23:53:07.563 DEBUG (MainThread) [custom_components.smart_thermostat.climate] climate.tent_pid_humidity_exhaust: New PID control output: -100 (error = -8.55, dt = 0.00, p=-85.50, i=-40.30, d=0.00, e=0.00)
2025-02-12 23:53:07.563 INFO (MainThread) [custom_components.smart_thermostat.climate] climate.tent_pid_humidity_exhaust: Change state of fan.tent_controller_fan to 100
```