### PR TITLE
Update README.md PWM Parameter Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,7 +253,7 @@ values instead.
 * **pwm** (Optional): Set period of the pulse width modulation. If too long, the response time of 
 the thermostat will be too slow, leading to lower accuracy of temperature control. Can be float in 
 seconds or time hh:mm:ss (default 15mn). Set to 0 when using heater entity with direct input of 
-0/100% values like valves or lights.
+0/100% values like valves or lights. Do not set if your heater is controlled by a switch entity that requires an ON/OFF state.
 * **min_cycle_duration** (Optional): Set a minimum amount of time that the switch specified in the 
 heater option must be in its current state prior to being switched either off or on (useful to 
 protect boilers). Can be float in seconds or time hh:mm:ss (default 0s).


### PR DESCRIPTION
Noted that PWM cannot be set when your heater is controlled by a switch entity requiring an ON/OFF state.
If PWM is set to 0, it sets a value of 0 or 100, which causes a log error and does not trigger the switch device, and gives a non descriptive error.

Example logs
```
2025-04-04 13:00:59.843 INFO (MainThread) [custom_components.smart_thermostat.climate] climate.oven_pid: Change state of switch.example_switch to 100.0
2025-04-04 13:00:59.843 WARNING (MainThread) [homeassistant.helpers.service] Referenced entities switch.example_switch are missing or not currently available
```