### PR TITLE
Allow clear_integral service to set a non zero value

### DIFF
--- a/custom_components/smart_thermostat/climate.py
+++ b/custom_components/smart_thermostat/climate.py
@@ -242,7 +242,9 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
     )
     platform.async_register_entity_service(  # type: ignore
         "clear_integral",
-        {},
+        {
+            vol.Optional("value", default=0.0): vol.Coerce(float),
+        },
         "clear_integral",
     )
 
@@ -814,9 +816,11 @@ class SmartThermostat(ClimateEntity, RestoreEntity, ABC):
 
     async def clear_integral(self, **kwargs):
         """Clear the integral value."""
-        self._pid_controller.integral = 0.0
-        self._i = self._pid_controller.integral
-        self.async_write_ha_state()
+        value = float(kwargs.get("value", 0.0))
+        if self._pid_controller is not None:
+            self._pid_controller.integral = value
+            self._i = self._pid_controller.integral
+            self.async_write_ha_state()
 
     @property
     def min_temp(self):

--- a/custom_components/smart_thermostat/climate.py
+++ b/custom_components/smart_thermostat/climate.py
@@ -817,10 +817,9 @@ class SmartThermostat(ClimateEntity, RestoreEntity, ABC):
     async def clear_integral(self, **kwargs):
         """Clear the integral value."""
         value = float(kwargs.get("value", 0.0))
-        if self._pid_controller is not None:
-            self._pid_controller.integral = value
-            self._i = self._pid_controller.integral
-            self.async_write_ha_state()
+        self._pid_controller.integral = value
+        self._i = self._pid_controller.integral
+        self.async_write_ha_state()
 
     @property
     def min_temp(self):

--- a/custom_components/smart_thermostat/services.yaml
+++ b/custom_components/smart_thermostat/services.yaml
@@ -1,6 +1,11 @@
 clear_integral:
   name: Clear Integral
   description: Clears the integrating part of the PID.
+  fields:
+    value:
+      description: Integral value to apply
+      example: 1.0
+      required: false
   target:
     entity:
       integration: smart_thermostat


### PR DESCRIPTION
This change extends the existing clear_integral service so the PID integral term can be reset to an arbitrary value instead of always being forced to zero. When no value is provided, the integral is still cleared to 0.

In some cases the integral term may be known or calculable to be close to the correct steady state value. Allowing it to be restored or deliberately biased makes it possible to slow integral action and reduce overshoot after mode changes, restarts, or manual intervention.

Example of usage:

```
action: smart_thermostat.clear_integral
data:
  value: 10
target:
  entity_id: climate.controller_name
```