### PR TITLE
Fix: use valve.open_valve/close_valve for valve entities

### DIFF
--- a/custom_components/smart_thermostat/climate.py
+++ b/custom_components/smart_thermostat/climate.py
@@ -976,12 +976,17 @@ class SmartThermostat(ClimateEntity, RestoreEntity, ABC):
                          self.entity_id, ", ".join([entity for entity in self.heater_or_cooler_entity]))
             return
         for heater_or_cooler_entity in self.heater_or_cooler_entity:
-            data = {ATTR_ENTITY_ID: heater_or_cooler_entity}
-            if self._heater_polarity_invert:
-                service = SERVICE_TURN_OFF
+            if heater_or_cooler_entity.startswith('valve.'):
+                data = {ATTR_ENTITY_ID: heater_or_cooler_entity}
+                await self.hass.services.async_call(
+                    VALVE_DOMAIN, 'open_valve', data)
             else:
-                service = SERVICE_TURN_ON
-            await self.hass.services.async_call(HA_DOMAIN, service, data)
+                data = {ATTR_ENTITY_ID: heater_or_cooler_entity}
+                if self._heater_polarity_invert:
+                    service = SERVICE_TURN_OFF
+                else:
+                    service = SERVICE_TURN_ON
+                await self.hass.services.async_call(HA_DOMAIN, service, data)
 
     async def _async_heater_turn_off(self, force=False):
         """Turn heater toggleable device off."""
@@ -1001,12 +1006,17 @@ class SmartThermostat(ClimateEntity, RestoreEntity, ABC):
             if entity is None:
                 continue
             for heater_or_cooler_entity in self.heater_or_cooler_entity:
-                data = {ATTR_ENTITY_ID: heater_or_cooler_entity}
-                if self._heater_polarity_invert:
-                    service = SERVICE_TURN_ON
+                if heater_or_cooler_entity.startswith('valve.'):
+                    data = {ATTR_ENTITY_ID: heater_or_cooler_entity}
+                    await self.hass.services.async_call(
+                        VALVE_DOMAIN, 'close_valve', data)
                 else:
-                    service = SERVICE_TURN_OFF
-                await self.hass.services.async_call(HA_DOMAIN, service, data)
+                    data = {ATTR_ENTITY_ID: heater_or_cooler_entity}
+                    if self._heater_polarity_invert:
+                        service = SERVICE_TURN_ON
+                    else:
+                        service = SERVICE_TURN_OFF
+                    await self.hass.services.async_call(HA_DOMAIN, service, data)
 
     async def _async_set_valve_value(self, value: float):
         _LOGGER.info("%s: Change state of %s to %s", self.entity_id,


### PR DESCRIPTION
## Summary
- When a heater/cooler entity is a `valve.*` entity, `_async_heater_turn_on()` and `_async_heater_turn_off()` now call `valve.open_valve` / `valve.close_valve` instead of `homeassistant.turn_on` / `homeassistant.turn_off`
- The `homeassistant.turn_on/off` services do not support valve entities, causing `homeassistant.turn_off does not support this entity` warnings and no actual valve control
- Non-valve entities (switches, lights, etc.) continue to use the existing `homeassistant.turn_on/off` logic unchanged

## Problem
When using valve entities as heaters (e.g. floor heating valves from ESPHome), SAT calls `homeassistant.turn_on/off` which is not supported for the `valve` domain. This results in:
```
homeassistant.turn_off does not support this entity valve.heating_controller_bedroom_valve_bedroom
```

The valve entity is defined with `VALVE_DOMAIN = "valve"` and proper `open_valve`/`close_valve` services exist, but only `_async_set_valve_value()` uses them — the PWM on/off methods did not.

## Test plan
- [ ] Verify valve entities open/close correctly when thermostat activates heating
- [ ] Verify non-valve heater entities (switches) still work unchanged
- [ ] Verify polarity invert still works for non-valve entities
- [ ] Check HA logs for absence of `does not support this entity` warnings